### PR TITLE
Improve build performance by caching the navigation menu.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -152,6 +152,7 @@ ga_tracking_anonymize_ip: true # Use GDPR compliant Google Analytics settings (t
 
 plugins:
   - jekyll-seo-tag
+  - jekyll-include-cache
 
 kramdown:
   syntax_highlighter_opts:

--- a/_includes/js/custom.js
+++ b/_includes/js/custom.js
@@ -1,0 +1,21 @@
+(function() {
+  /**
+   * Adds the 'active' class to the currently selected nav link, its list item and its ancestral links/items.
+   */
+  function selectActiveNav() {
+    var activeLink = document.querySelector("a.nav-list-link[href='" + window.location.pathname + "']");
+    if (activeLink !== null) {
+      var navItem = activeLink.closest('.nav-list-item');
+      while (navItem !== null) {
+        navItem.classList.add('active');
+        navItem.querySelector('.nav-list-link').classList.add('active');
+
+        navItem = navItem.parentElement.closest('.nav-list-item');
+      }
+    }
+  }
+
+  jtd.onReady(function() {
+    selectActiveNav();
+  });
+})();

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -13,7 +13,7 @@
 
     The case-sensitivity of string sorting is determined by `site.nav_sort`.
   {%- endcomment -%}
-  
+
   {%- assign string_ordered_pages = titled_pages
         | where_exp:"item", "item.nav_order == nil" -%}
   {%- assign nav_ordered_pages = titled_pages
@@ -34,9 +34,9 @@
       {%- assign number_ordered_pages = number_ordered_pages | concat: group.items -%}
     {%- endif -%}
   {%- endfor -%}
-  
+
   {%- assign sorted_number_ordered_pages = number_ordered_pages | sort:"nav_order" -%}
-  
+
   {%- comment -%}
     The string_ordered_pages have to be sorted by nav_order, and otherwise title
     (where appending the empty string to a numeric title converts it to a string).
@@ -56,32 +56,32 @@
   {%- endfor -%}
 
   {%- assign pages_list = sorted_number_ordered_pages | concat: sorted_string_ordered_pages -%}
-  
+
   {%- for node in pages_list -%}
     {%- if node.parent == nil -%}
       {%- unless node.nav_exclude -%}
-      <li class="nav-list-item{% if page.url == node.url or page.parent == node.title or page.grand_parent == node.title %} active{% endif %}">
+      <li class="nav-list-item">
         {%- if node.has_children -%}
           <a href="#" class="nav-list-expander"><svg viewBox="0 0 24 24"><use xlink:href="#svg-arrow-right"></use></svg></a>
         {%- endif -%}
-        <a href="{{ node.url | absolute_url }}" class="nav-list-link{% if page.url == node.url %} active{% endif %}">{{ node.title }}</a>
+        <a href="{{ node.url | absolute_url }}" class="nav-list-link">{{ node.title }}</a>
         {%- if node.has_children -%}
           {%- assign children_list = pages_list | where: "parent", node.title -%}
           <ul class="nav-list ">
           {%- for child in children_list -%}
             {%- unless child.nav_exclude -%}
-            <li class="nav-list-item {% if page.url == child.url or page.parent == child.title %} active{% endif %}">
+            <li class="nav-list-item">
               {%- if child.has_children -%}
                 <a href="#" class="nav-list-expander"><svg viewBox="0 0 24 24"><use xlink:href="#svg-arrow-right"></use></svg></a>
               {%- endif -%}
-              <a href="{{ child.url | absolute_url }}" class="nav-list-link{% if page.url == child.url %} active{% endif %}">{{ child.title }}</a>
+              <a href="{{ child.url | absolute_url }}" class="nav-list-link">{{ child.title }}</a>
               {%- if child.has_children -%}
                 {%- assign grand_children_list = pages_list | where: "parent", child.title | where: "grand_parent", node.title -%}
                 <ul class="nav-list">
                 {%- for grand_child in grand_children_list -%}
                   {%- unless grand_child.nav_exclude -%}
-                  <li class="nav-list-item {% if page.url == grand_child.url %} active{% endif %}">
-                    <a href="{{ grand_child.url | absolute_url }}" class="nav-list-link{% if page.url == grand_child.url %} active{% endif %}">{{ grand_child.title }}</a>
+                  <li class="nav-list-item">
+                    <a href="{{ grand_child.url | absolute_url }}" class="nav-list-link">{{ grand_child.title }}</a>
                   </li>
                   {%- endunless -%}
                 {%- endfor -%}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -58,11 +58,11 @@ layout: table_wrappers
             {% if collections_size > 1 %}
               <div class="nav-category">{{ collection_value.name }}</div>
             {% endif %}
-            {% include nav.html pages=collection %}
+            {% include_cached nav.html pages=collection %}
           {% endif %}
         {% endfor %}
       {% else %}
-        {% include nav.html pages=site.html_pages %}
+        {% include_cached nav.html pages=site.html_pages %}
       {% endif %}
     </nav>
     <footer class="site-footer">

--- a/just-the-docs.gemspec
+++ b/just-the-docs.gemspec
@@ -17,4 +17,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "jekyll", ">= 3.8.5"
   spec.add_runtime_dependency "jekyll-seo-tag", "~> 2.0"
   spec.add_runtime_dependency "rake", ">= 12.3.1", "< 13.1.0"
+  spec.add_runtime_dependency "jekyll-include-cache"
 end

--- a/just-the-docs.gemspec
+++ b/just-the-docs.gemspec
@@ -13,9 +13,8 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r{^(assets|bin|_layouts|_includes|lib|Rakefile|_sass|LICENSE|README)}i) }
   spec.executables   << 'just-the-docs'
 
-  spec.add_development_dependency "bundler", "~> 2.1.4"
+  spec.add_development_dependency "bundler", [">= 2.1.4", "< 3.0"]
   spec.add_runtime_dependency "jekyll", ">= 3.8.5"
   spec.add_runtime_dependency "jekyll-seo-tag", "~> 2.0"
   spec.add_runtime_dependency "rake", ">= 12.3.1", "< 13.1.0"
-
 end


### PR DESCRIPTION
The nav takes a _huge_ amount of time to render as it has to be built for every single page:

```
Build Process Summary:

| PHASE      |     TIME |
+------------+----------+
| RESET      |   0.0002 |
| READ       |   2.3056 |
| GENERATE   |   0.0896 |
| RENDER     | 905.4087 |
| CLEANUP    |   0.0252 |
| WRITE      |   0.7982 |
+------------+----------+
| TOTAL TIME | 908.6275 |


Site Render Stats:

| Filename                                                                                   | Count |      Bytes |     Time |
+--------------------------------------------------------------------------------------------+-------+------------+----------+
| just-the-docs-e1397866405a/_layouts/default.html                                           |   673 |  44777.18K |  900.045 |
| just-the-docs-e1397866405a/_includes/nav.html                                              |   673 |  32072.23K |  875.805 |
...
```

This substantially improves the performance of the build by adding the `jekyll-include-cache` plugin and using that to include `nav.html`.

The nav file previously handled selecting the active page in the menu (ensuring it's highlighted and the menu expanded), with this now being cached this functionality has been moved to javascript.

The docs now build in about 10-15 seconds:

```
Build Process Summary:

| PHASE      |    TIME |
+------------+---------+
| RESET      |  0.0002 |
| READ       |  0.5010 |
| GENERATE   |  0.1098 |
| RENDER     |  9.0865 |
| CLEANUP    |  0.0372 |
| WRITE      |  2.8658 |
+------------+---------+
| TOTAL TIME | 12.6005 |


Site Render Stats:

| Filename                                                                                   | Count |      Bytes |   Time |
+--------------------------------------------------------------------------------------------+-------+------------+--------+
| just-the-docs-7bc6906bf38e/_layouts/default.html                                           |   673 |  44498.25K |  6.018 |
| just-the-docs-7bc6906bf38e/_includes/vendor/anchor_headings.html                           |   673 |   7019.53K |  1.892 |
| _includes/head.html                                                                        |   673 |   2113.97K |  1.707 |
| just-the-docs-7bc6906bf38e/_includes/nav.html                                              |     1 |     47.38K |  1.612 |
...
..
```

Nav highlighting/expanding working at top, child, grandchild levels:
![Screen Shot 2021-06-23 at 11 12 15 am](https://user-images.githubusercontent.com/1217111/123019745-6bec1300-d414-11eb-9d29-d1f67e2ed754.png)
![Screen Shot 2021-06-23 at 11 11 59 am](https://user-images.githubusercontent.com/1217111/123019755-6f7f9a00-d414-11eb-8a83-d7259c8d6ba9.png)
![Screen Shot 2021-06-23 at 11 12 10 am](https://user-images.githubusercontent.com/1217111/123019752-6ee70380-d414-11eb-9a38-4a3ae8c0e7d3.png)
