### PR TITLE
Add grand_parent = nil filter for first level child pages.

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -66,7 +66,7 @@
         {%- endif -%}
         <a href="{{ node.url | absolute_url }}" class="nav-list-link">{{ node.title }}</a>
         {%- if node.has_children -%}
-          {%- assign children_list = pages_list | where: "parent", node.title -%}
+          {%- assign children_list = pages_list | where: "parent", node.title | where: "grand_parent", nil -%}
           <ul class="nav-list ">
           {%- for child in children_list -%}
             {%- unless child.nav_exclude -%}


### PR DESCRIPTION
Fixes this issue where this `Onboarding` page was duplicated under the top level `Process` page:

![Screen Shot 2021-06-23 at 12 11 22 pm](https://user-images.githubusercontent.com/1217111/123025345-d786ae00-d41d-11eb-9eda-0665c5a2b730.png)

Proof:
![Screen Shot 2021-06-23 at 12 23 33 pm](https://user-images.githubusercontent.com/1217111/123025354-db1a3500-d41d-11eb-90e8-3dce9064b906.png)
